### PR TITLE
feat(scan-for-ms): scan through vault sigs to find ms

### DIFF
--- a/src/components/MultisigInput.tsx
+++ b/src/components/MultisigInput.tsx
@@ -17,8 +17,8 @@ const MultisigInput = ({ onUpdate }: { onUpdate: () => void }) => {
   };
 
   return (
-    <div className="mx-auto min-h-screen w-full max-w-4xl space-y-4 px-4 py-6 sm:px-6 md:py-10 lg:px-8">
-      <h1>Enter Multisig Address</h1>
+    <div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-6 sm:px-6 md:py-10 lg:px-8">
+      <h1>Enter Multisig Config Address</h1>
       <p className="text-sm text-gray-500">
         There is no multisig set in Local Storage. Set it by entering its Public Key below.
       </p>

--- a/src/components/MultisigLookup.tsx
+++ b/src/components/MultisigLookup.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react';
+import { Input } from './ui/input';
+import { Button } from './ui/button';
+import { useMultisigData } from '../hooks/useMultisigData';
+import {
+  AddressLookupTableAccount,
+  AddressLookupTableAccountArgs,
+  ConfirmedSignatureInfo,
+  Connection,
+  DecompileArgs,
+  PublicKey,
+  TransactionMessage,
+  VersionedTransactionResponse,
+} from '@solana/web3.js';
+import { identifyInstructionByDiscriminator } from '../lib/discriminators';
+import { useMultisigAddress } from '../hooks/useMultisigAddress';
+
+interface MultisigLookupProps {
+  onUpdate: () => void;
+}
+
+const MultisigLookup: React.FC<MultisigLookupProps> = ({ onUpdate }) => {
+  const { connection, programId } = useMultisigData();
+  const { setMultisigAddress } = useMultisigAddress();
+
+  const [vaultAddress, setVaultAddress] = useState<string>('');
+  const [searching, setSearching] = useState<boolean>(false);
+  const [statusMessages, setStatusMessages] = useState<string[]>([]);
+  const [foundMultisigs, setFoundMultisigs] = useState<Set<string>>(new Set());
+
+  const search = async (): Promise<void> => {
+    if (!vaultAddress) return;
+
+    setSearching(true);
+    setStatusMessages([]);
+
+    const vaultPubkey = new PublicKey(vaultAddress);
+    const signatures: ConfirmedSignatureInfo[] = await connection.getSignaturesForAddress(
+      vaultPubkey,
+      { limit: 100 }
+    );
+    if (signatures.length > 0) {
+      setStatusMessages([`Found ${signatures.length} signatures`]);
+    } else {
+      setStatusMessages([`There was an issue retrieving the signatures, search again`]);
+    }
+
+    for (const signature of signatures) {
+      setStatusMessages((prev) => [
+        ...prev,
+        `Scanning signature ${signature.signature} - in progress`,
+      ]);
+
+      const tx: VersionedTransactionResponse | null = await connection.getTransaction(
+        signature.signature,
+        {
+          commitment: 'confirmed',
+          maxSupportedTransactionVersion: 0,
+        }
+      );
+
+      if (tx) {
+        const result = await processTransaction(tx, connection, programId);
+        if (result) {
+          if (result.decompiled) {
+            for (let i = 0; i < result.decompiled.instructions.length; i++) {
+              let identified = identifyInstructionByDiscriminator(
+                result.decompiled.instructions[i],
+                programId
+              );
+              if (identified) {
+                let msKey =
+                  result.decompiled.instructions[i].keys[
+                    identified.multisigAccountIndex
+                  ].pubkey.toBase58();
+                setFoundMultisigs((prevState) => {
+                  return prevState.add(msKey);
+                });
+              }
+            }
+          }
+        }
+      }
+
+      setStatusMessages((prev) =>
+        prev.map((msg) =>
+          msg.includes(signature.signature)
+            ? `Scanning signature ${signature.signature} - done`
+            : msg
+        )
+      );
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    setSearching(false);
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-4 px-4 py-6 sm:px-6 md:py-10 lg:px-8">
+      <h1>Search for Multisig Config Address</h1>
+      <p className="text-sm text-gray-500">
+        The multisig config address is used to derive the vaults and relevant authority. This may
+        not be explicitly known. Don't know the multisig config address? Lookup your Squad by the
+        vault address that you use to send and receive funds.
+      </p>
+      <Input
+        type="text"
+        placeholder="Vault Address"
+        className="mt-2 w-full rounded-md border border-gray-300 px-4 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-200 sm:text-sm"
+        value={vaultAddress}
+        onChange={(e) => setVaultAddress(e.target.value.trim())}
+      />
+      <Button onClick={search} className="mt-4" disabled={searching}>
+        {searching ? 'Searching...' : 'Search'}
+      </Button>
+
+      {statusMessages.length > 0 && (
+        <ul className="mt-4 h-[100px] overflow-y-auto rounded border border-gray-300 p-2 text-sm text-gray-600">
+          {statusMessages.map((msg, index) => (
+            <li key={index}>
+              <pre className="text-xs">{msg}</pre>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {foundMultisigs.size > 0 && (
+        <>
+          Found Multisig Config Address!
+          <ul className="mt-4">
+            {[...foundMultisigs].map((msKey, index) => {
+              return (
+                <li key={`ms-${index}`}>
+                  <Button
+                    onClick={async () => {
+                      await setMultisigAddress.mutateAsync(msKey); // Save using React Query
+                    }}
+                  >
+                    Use {msKey}
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+};
+
+const processTransaction = async (
+  tx: VersionedTransactionResponse,
+  connection: Connection,
+  programId: PublicKey
+) => {
+  const includesSquadsProgram = tx.transaction.message.staticAccountKeys.find((val) =>
+    val.equals(programId)
+  );
+  if (includesSquadsProgram) {
+    const { addressTableLookups } = tx.transaction.message;
+    const altAddresses = addressTableLookups.map((addressTableLookup) =>
+      addressTableLookup.accountKey.toBase58()
+    );
+    const altArgsArray: AddressLookupTableAccountArgs[] = [];
+
+    for (let i = 0; i < altAddresses.length; i++) {
+      let altPubkey = new PublicKey(altAddresses[i]);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // check previous state first to see if we already have it
+      const alreadyCheckedState = altArgsArray.find((preAltArg) => preAltArg.key.equals(altPubkey));
+      if (!alreadyCheckedState) {
+        console.log('we dont have alt for this address, fetching', altPubkey);
+        const altState = await connection.getAddressLookupTable(altPubkey);
+        if (altState.value) {
+          altArgsArray.push({
+            key: altPubkey,
+            state: altState.value.state,
+          });
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    const decompileArgs: DecompileArgs = {
+      addressLookupTableAccounts: altArgsArray.map(
+        (altArgs) => new AddressLookupTableAccount(altArgs)
+      ),
+    };
+    const decompileTx = TransactionMessage.decompile(tx.transaction.message, decompileArgs);
+    return { tx, decompiled: decompileTx };
+  }
+};
+
+export default MultisigLookup;

--- a/src/components/MultisigLookup.tsx
+++ b/src/components/MultisigLookup.tsx
@@ -37,7 +37,7 @@ const MultisigLookup: React.FC<MultisigLookupProps> = ({ onUpdate }) => {
     const vaultPubkey = new PublicKey(vaultAddress);
     const signatures: ConfirmedSignatureInfo[] = await connection.getSignaturesForAddress(
       vaultPubkey,
-      { limit: 100 }
+      { limit: 300 }
     );
     if (signatures.length > 0) {
       setStatusMessages([`Found ${signatures.length} signatures`]);

--- a/src/components/RenderMultisigRoute.tsx
+++ b/src/components/RenderMultisigRoute.tsx
@@ -1,6 +1,7 @@
 import MultisigInput from './MultisigInput';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import Overview from '@/components/Overview';
+import MultisigLookup from './MultisigLookup';
 
 interface RenderRouteProps {
   children: React.ReactNode;
@@ -18,6 +19,7 @@ export default function RenderMultisigRoute() {
       ) : (
         <>
           <MultisigInput onUpdate={() => null} />
+          <MultisigLookup onUpdate={() => null} />
         </>
       )}
     </>

--- a/src/lib/discriminators.ts
+++ b/src/lib/discriminators.ts
@@ -1,0 +1,47 @@
+// to assist in the search based off of vault including relevant discriminators
+// ie, we can find the multisig config address by identifying where its positioned if given a vault address
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+
+const batchExecuteTransactionInstructionDiscriminator = [172, 44, 179, 152, 21, 127, 234, 180];
+const spendingLimitUseInstructionDiscriminator = [16, 57, 130, 127, 193, 20, 155, 134];
+const vaultTransactionExecuteInstructionDiscriminator = [194, 8, 161, 87, 153, 164, 25, 171];
+
+export interface DiscriminatorMultisigPosition {
+  discriminator: number[];
+  multisigAccountIndex: number;
+  label: string;
+}
+export const MULTISIG_ACCOUNT_POSITIONS: DiscriminatorMultisigPosition[] = [
+  {
+    discriminator: batchExecuteTransactionInstructionDiscriminator,
+    multisigAccountIndex: 0,
+    label: 'batchExecuteTransactionInstruction',
+  },
+  {
+    discriminator: spendingLimitUseInstructionDiscriminator,
+    multisigAccountIndex: 0,
+    label: 'spendingLimitUseInstruction',
+  },
+  {
+    discriminator: vaultTransactionExecuteInstructionDiscriminator,
+    multisigAccountIndex: 0,
+    label: 'vaultTransactionExecuteInstruction',
+  },
+];
+
+export const identifyInstructionByDiscriminator = (
+  instruction: TransactionInstruction,
+  programId: PublicKey
+) => {
+  if (!programId.equals(instruction.programId)) {
+    return null;
+  }
+  const discrim = Array.from(instruction.data.slice(0, 8));
+  const matches = MULTISIG_ACCOUNT_POSITIONS.find((msp) => {
+    return arraysEqual(msp.discriminator, discrim);
+  });
+  return matches || null;
+};
+
+const arraysEqual = (a: number[], b: number[]): boolean =>
+  a.length === b.length && a.every((val, index) => val === b[index]);


### PR DESCRIPTION
Enables rudimentary signature searching to locate a multisig address from a vault address (since they can't be derived backwards).