### PR TITLE
fix(members): state updates for members and txs

### DIFF
--- a/src/components/AddMemberInput.tsx
+++ b/src/components/AddMemberInput.tsx
@@ -89,7 +89,10 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
     if (!sent[0]) {
       throw `Transaction failed or unable to confirm. Check ${signature}`;
     }
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+    ]);
   };
   return (
     <div>

--- a/src/components/AddMemberInput.tsx
+++ b/src/components/AddMemberInput.tsx
@@ -2,7 +2,7 @@ import { Button } from './ui/button';
 import { formatTransactionError } from '@/lib/utils';
 import { Input } from './ui/input';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import * as multisig from '@sqds/multisig';
 import { PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
@@ -31,6 +31,7 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
   const bigIntTransactionIndex = BigInt(transactionIndex);
   const { connection } = useMultisigData();
   const queryClient = useQueryClient();
+  const signatureRef = useRef<string>('');
   const hasAccess = useAccess();
   const addMember = async () => {
     invariant(multisigConfig, 'invalid multisig conf data');
@@ -79,6 +80,8 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -101,7 +104,7 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
             id: 'transaction',
             loading: 'Loading...',
             success: 'Add member action proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
           })
         }
         disabled={!isPublickey(member) || !hasAccess}

--- a/src/components/AddMemberInput.tsx
+++ b/src/components/AddMemberInput.tsx
@@ -37,7 +37,7 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
     invariant(multisigConfig, 'invalid multisig conf data');
     if (!wallet.publicKey) {
       walletModal.setVisible(true);
-      return;
+      throw 'Wallet not connected';
     }
     const newMemberKey = new PublicKey(member);
     const memberExists = isMember(newMemberKey, multisigConfig.members);
@@ -77,18 +77,22 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Add member action proposed.', { id: 'transaction' });
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['transactions'] }),
       queryClient.invalidateQueries({ queryKey: ['multisig'] }),
@@ -102,14 +106,16 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
         className="mb-3"
       />
       <Button
-        onClick={() =>
-          toast.promise(addMember, {
-            id: 'transaction',
-            loading: 'Loading...',
-            success: 'Add member action proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-          })
-        }
+        onClick={async () => {
+          try {
+            await addMember();
+          } catch (e) {
+            toast.error(
+              `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+              { id: 'transaction' }
+            );
+          }
+        }}
         disabled={!isPublickey(member) || !hasAccess}
       >
         Add Member

--- a/src/components/AddMemberInput.tsx
+++ b/src/components/AddMemberInput.tsx
@@ -1,4 +1,5 @@
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import { Input } from './ui/input';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useState } from 'react';
@@ -100,7 +101,7 @@ const AddMemberInput = ({ multisigPda, transactionIndex, programId }: AddMemberI
             id: 'transaction',
             loading: 'Loading...',
             success: 'Add member action proposed.',
-            error: (e) => `Failed to propose: ${e}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
           })
         }
         disabled={!isPublickey(member) || !hasAccess}

--- a/src/components/ApproveButton.tsx
+++ b/src/components/ApproveButton.tsx
@@ -43,11 +43,12 @@ const ApproveButton = ({
     ? multisig.types.Permissions.has(connectedMember.permissions, multisig.types.Permission.Vote)
     : false;
   const isDisabled =
+    !wallet.publicKey ||
     isAccountClosed ||
     isStale ||
     terminalStatuses.includes(proposalStatus || 'None') ||
     hasAlreadyApproved ||
-    (!!wallet.publicKey && !hasVotePermission);
+    !hasVotePermission;
   const { connection } = useMultisigData();
   const queryClient = useQueryClient();
   const signatureRef = useRef<string>('');

--- a/src/components/ApproveButton.tsx
+++ b/src/components/ApproveButton.tsx
@@ -8,6 +8,8 @@ import { toast } from 'sonner';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import { useQueryClient } from '@tanstack/react-query';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
+import { useMultisig } from '@/hooks/useServices';
+import { isMember } from '@/lib/utils';
 
 type ApproveButtonProps = {
   multisigPda: string;
@@ -15,6 +17,8 @@ type ApproveButtonProps = {
   proposalStatus: string;
   programId: string;
   isStale: boolean;
+  approvedMembers: PublicKey[];
+  isAccountClosed: boolean;
 };
 
 const ApproveButton = ({
@@ -23,11 +27,27 @@ const ApproveButton = ({
   proposalStatus,
   programId,
   isStale,
+  approvedMembers,
+  isAccountClosed,
 }: ApproveButtonProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
+  const { data: multisigConfig } = useMultisig();
   const terminalStatuses = ['Rejected', 'Approved', 'Executing', 'Executed', 'Cancelled'];
-  const isDisabled = isStale || terminalStatuses.includes(proposalStatus || 'None');
+  const hasAlreadyApproved =
+    !!wallet.publicKey && approvedMembers.some((k) => k.equals(wallet.publicKey!));
+  const connectedMember = wallet.publicKey
+    ? isMember(wallet.publicKey, multisigConfig?.members ?? [])
+    : undefined;
+  const hasVotePermission = connectedMember
+    ? multisig.types.Permissions.has(connectedMember.permissions, multisig.types.Permission.Vote)
+    : false;
+  const isDisabled =
+    isAccountClosed ||
+    isStale ||
+    terminalStatuses.includes(proposalStatus || 'None') ||
+    hasAlreadyApproved ||
+    !hasVotePermission;
   const { connection } = useMultisigData();
   const queryClient = useQueryClient();
   const signatureRef = useRef<string>('');

--- a/src/components/ApproveButton.tsx
+++ b/src/components/ApproveButton.tsx
@@ -87,33 +87,37 @@ const ApproveButton = ({
       programId: programId ? new PublicKey(programId) : multisig.PROGRAM_ID,
     });
     transaction.add(approveProposalInstruction);
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, {
-      duration: Infinity,
-    });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Transaction approved.', { id: 'transaction' });
     await queryClient.invalidateQueries({ queryKey: ['transactions'] });
   };
   return (
     <Button
       disabled={isDisabled}
-      onClick={() =>
-        toast.promise(approveProposal, {
-          id: 'transaction',
-          loading: 'Loading...',
-          success: 'Transaction approved.',
-          error: (e) => `Failed to approve: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-        })
-      }
+      onClick={async () => {
+        try {
+          await approveProposal();
+        } catch (e) {
+          toast.error(
+            `Failed to approve: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+            { id: 'transaction' }
+          );
+        }
+      }}
       className="mr-2"
     >
       Approve

--- a/src/components/ApproveButton.tsx
+++ b/src/components/ApproveButton.tsx
@@ -47,7 +47,7 @@ const ApproveButton = ({
     isStale ||
     terminalStatuses.includes(proposalStatus || 'None') ||
     hasAlreadyApproved ||
-    !hasVotePermission;
+    (!!wallet.publicKey && !hasVotePermission);
   const { connection } = useMultisigData();
   const queryClient = useQueryClient();
   const signatureRef = useRef<string>('');

--- a/src/components/ApproveButton.tsx
+++ b/src/components/ApproveButton.tsx
@@ -9,7 +9,7 @@ import { useMultisigData } from '@/hooks/useMultisigData';
 import { useQueryClient } from '@tanstack/react-query';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
 import { useMultisig } from '@/hooks/useServices';
-import { isMember } from '@/lib/utils';
+import { isMember, formatTransactionError } from '@/lib/utils';
 
 type ApproveButtonProps = {
   multisigPda: string;
@@ -110,7 +110,7 @@ const ApproveButton = ({
           id: 'transaction',
           loading: 'Loading...',
           success: 'Transaction approved.',
-          error: (e) => `Failed to approve: ${e}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+          error: (e) => `Failed to approve: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
         })
       }
       className="mr-2"

--- a/src/components/ChangeThresholdInput.tsx
+++ b/src/components/ChangeThresholdInput.tsx
@@ -91,18 +91,22 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Threshold change proposed.', { id: 'transaction' });
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['transactions'] }),
       queryClient.invalidateQueries({ queryKey: ['multisig'] }),
@@ -117,14 +121,16 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
         className="mb-3"
       />
       <Button
-        onClick={() =>
-          toast.promise(changeThreshold, {
-            id: 'transaction',
-            loading: 'Loading...',
-            success: 'Threshold change proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-          })
-        }
+        onClick={async () => {
+          try {
+            await changeThreshold();
+          } catch (e) {
+            toast.error(
+              `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+              { id: 'transaction' }
+            );
+          }
+        }}
         disabled={
           !hasAccess ||
           !threshold ||

--- a/src/components/ChangeThresholdInput.tsx
+++ b/src/components/ChangeThresholdInput.tsx
@@ -13,6 +13,7 @@ import { types as multisigTypes } from '@sqds/multisig';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
 import { useQueryClient } from '@tanstack/react-query';
 import { useMultisigData } from '../hooks/useMultisigData';
+import { useAccess } from '../hooks/useAccess';
 import { buildProposalAndApproveIx } from '../lib/multisigUtils';
 
 type ChangeThresholdInputProps = {
@@ -22,6 +23,7 @@ type ChangeThresholdInputProps = {
 
 const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThresholdInputProps) => {
   const { data: multisigConfig } = useMultisig();
+  const hasAccess = useAccess();
   const [threshold, setThreshold] = useState('');
   const wallet = useWallet();
   const walletModal = useWalletModal();
@@ -54,7 +56,7 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
   const changeThreshold = async () => {
     if (!wallet.publicKey) {
       walletModal.setVisible(true);
-      return;
+      throw 'Wallet not connected';
     }
     const validateError = validateThreshold();
     if (validateError) {
@@ -121,7 +123,9 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
           })
         }
         disabled={
-          !threshold || (!!multisigConfig && multisigConfig.threshold == parseInt(threshold, 10))
+          !hasAccess ||
+          !threshold ||
+          (!!multisigConfig && multisigConfig.threshold == parseInt(threshold, 10))
         }
       >
         Change Threshold

--- a/src/components/ChangeThresholdInput.tsx
+++ b/src/components/ChangeThresholdInput.tsx
@@ -2,7 +2,7 @@ import { Button } from './ui/button';
 import { formatTransactionError } from '@/lib/utils';
 import { Input } from './ui/input';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import * as multisig from '@sqds/multisig';
 import { Connection, PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
@@ -26,6 +26,7 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
   const wallet = useWallet();
   const walletModal = useWalletModal();
   const queryClient = useQueryClient();
+  const signatureRef = useRef<string>('');
 
   const bigIntTransactionIndex = BigInt(transactionIndex);
   const { connection, programId } = useMultisigData();
@@ -91,6 +92,8 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -114,7 +117,7 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
             id: 'transaction',
             loading: 'Loading...',
             success: 'Threshold change proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
           })
         }
         disabled={

--- a/src/components/ChangeThresholdInput.tsx
+++ b/src/components/ChangeThresholdInput.tsx
@@ -103,7 +103,10 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
     if (!sent[0]) {
       throw `Transaction failed or unable to confirm. Check ${signature}`;
     }
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+    ]);
   };
   return (
     <div>

--- a/src/components/ChangeThresholdInput.tsx
+++ b/src/components/ChangeThresholdInput.tsx
@@ -1,4 +1,5 @@
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import { Input } from './ui/input';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useState } from 'react';
@@ -113,7 +114,7 @@ const ChangeThresholdInput = ({ multisigPda, transactionIndex }: ChangeThreshold
             id: 'transaction',
             loading: 'Loading...',
             success: 'Threshold change proposed.',
-            error: (e) => `Failed to propose: ${e}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
           })
         }
         disabled={

--- a/src/components/ChangeUpgradeAuthorityInput.tsx
+++ b/src/components/ChangeUpgradeAuthorityInput.tsx
@@ -41,7 +41,7 @@ const ChangeUpgradeAuthorityInput = ({
   const changeUpgradeAuth = async () => {
     if (!wallet.publicKey) {
       walletModal.setVisible(true);
-      return;
+      throw 'Wallet not connected';
     }
     if (!multisigVault) {
       throw 'Multisig vault not found';
@@ -116,18 +116,22 @@ const ChangeUpgradeAuthorityInput = ({
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Upgrade authority change proposed.', { id: 'transaction' });
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['transactions'] }),
       queryClient.invalidateQueries({ queryKey: ['multisig'] }),
@@ -142,14 +146,16 @@ const ChangeUpgradeAuthorityInput = ({
         className="mb-3"
       />
       <Button
-        onClick={() =>
-          toast.promise(changeUpgradeAuth, {
-            id: 'transaction',
-            loading: 'Loading...',
-            success: 'Upgrade authority change proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-          })
-        }
+        onClick={async () => {
+          try {
+            await changeUpgradeAuth();
+          } catch (e) {
+            toast.error(
+              `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+              { id: 'transaction' }
+            );
+          }
+        }}
         disabled={
           !programId ||
           !isPublickey(newAuthority) ||

--- a/src/components/ChangeUpgradeAuthorityInput.tsx
+++ b/src/components/ChangeUpgradeAuthorityInput.tsx
@@ -128,7 +128,10 @@ const ChangeUpgradeAuthorityInput = ({
     if (!sent[0]) {
       throw `Transaction failed or unable to confirm. Check ${signature}`;
     }
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+    ]);
   };
   return (
     <div>

--- a/src/components/ChangeUpgradeAuthorityInput.tsx
+++ b/src/components/ChangeUpgradeAuthorityInput.tsx
@@ -2,7 +2,7 @@
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import * as multisig from '@sqds/multisig';
 import { formatTransactionError } from '@/lib/utils';
@@ -34,6 +34,7 @@ const ChangeUpgradeAuthorityInput = ({
   const wallet = useWallet();
   const walletModal = useWalletModal();
   const queryClient = useQueryClient();
+  const signatureRef = useRef<string>('');
   const bigIntTransactionIndex = BigInt(transactionIndex);
   const { connection, multisigAddress, vaultIndex, programId, multisigVault } = useMultisigData();
 
@@ -118,6 +119,8 @@ const ChangeUpgradeAuthorityInput = ({
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -141,7 +144,7 @@ const ChangeUpgradeAuthorityInput = ({
             id: 'transaction',
             loading: 'Loading...',
             success: 'Upgrade authority change proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
           })
         }
         disabled={

--- a/src/components/ChangeUpgradeAuthorityInput.tsx
+++ b/src/components/ChangeUpgradeAuthorityInput.tsx
@@ -5,6 +5,7 @@ import { useWallet } from '@solana/wallet-adapter-react';
 import { useState } from 'react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import * as multisig from '@sqds/multisig';
+import { formatTransactionError } from '@/lib/utils';
 import {
   AccountMeta,
   PublicKey,
@@ -140,7 +141,7 @@ const ChangeUpgradeAuthorityInput = ({
             id: 'transaction',
             loading: 'Loading...',
             success: 'Upgrade authority change proposed.',
-            error: (e) => `Failed to propose: ${e}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
           })
         }
         disabled={

--- a/src/components/CreateProgramUpgradeInput.tsx
+++ b/src/components/CreateProgramUpgradeInput.tsx
@@ -1,7 +1,7 @@
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { useWallet } from '@solana/wallet-adapter-react';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import * as multisig from '@sqds/multisig';
 import { formatTransactionError } from '@/lib/utils';
@@ -32,6 +32,7 @@ const CreateProgramUpgradeInput = ({
   transactionIndex,
 }: CreateProgramUpgradeInputProps) => {
   const queryClient = useQueryClient();
+  const signatureRef = useRef<string>('');
   const wallet = useWallet();
   const walletModal = useWalletModal();
 
@@ -141,6 +142,8 @@ const CreateProgramUpgradeInput = ({
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -170,7 +173,7 @@ const CreateProgramUpgradeInput = ({
             id: 'transaction',
             loading: 'Loading...',
             success: 'Upgrade authority change proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
           })
         }
         disabled={

--- a/src/components/CreateProgramUpgradeInput.tsx
+++ b/src/components/CreateProgramUpgradeInput.tsx
@@ -139,18 +139,22 @@ const CreateProgramUpgradeInput = ({
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Program upgrade proposed.', { id: 'transaction' });
     await queryClient.invalidateQueries({ queryKey: ['transactions'] });
   };
   return (
@@ -168,14 +172,16 @@ const CreateProgramUpgradeInput = ({
         className="mb-3"
       />
       <Button
-        onClick={() =>
-          toast.promise(changeUpgradeAuth, {
-            id: 'transaction',
-            loading: 'Loading...',
-            success: 'Upgrade authority change proposed.',
-            error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-          })
-        }
+        onClick={async () => {
+          try {
+            await changeUpgradeAuth();
+          } catch (e) {
+            toast.error(
+              `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+              { id: 'transaction' }
+            );
+          }
+        }}
         disabled={
           !programId ||
           !isPublickey(bufferAddress) ||

--- a/src/components/CreateProgramUpgradeInput.tsx
+++ b/src/components/CreateProgramUpgradeInput.tsx
@@ -4,6 +4,7 @@ import { useWallet } from '@solana/wallet-adapter-react';
 import { useState } from 'react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import * as multisig from '@sqds/multisig';
+import { formatTransactionError } from '@/lib/utils';
 import {
   AccountMeta,
   PublicKey,
@@ -169,7 +170,7 @@ const CreateProgramUpgradeInput = ({
             id: 'transaction',
             loading: 'Loading...',
             success: 'Upgrade authority change proposed.',
-            error: (e) => `Failed to propose: ${e}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
           })
         }
         disabled={

--- a/src/components/CreateSquadForm.tsx
+++ b/src/components/CreateSquadForm.tsx
@@ -1,5 +1,6 @@
 import { Button } from './ui/button';
 import { Input } from './ui/input';
+import { useRef } from 'react';
 import { Member, createMultisig } from '@/lib/createSquad';
 import { formatTransactionError } from '@/lib/utils';
 import { Keypair, PublicKey } from '@solana/web3.js';
@@ -39,6 +40,7 @@ export default function CreateSquadForm({}: {}) {
 
   const { connection, programId } = useMultisigData();
   const { setMultisigAddress } = useMultisigAddress();
+  const signatureRef = useRef<string>('');
   const validationRules = getValidationRules();
 
   const { formState, handleChange, handleAddMember, onSubmit } = useSquadForm<{
@@ -79,6 +81,8 @@ export default function CreateSquadForm({}: {}) {
         skipPreflight: true,
         signers: [createKey],
       });
+      signatureRef.current = signature;
+      toast.info(`Sending ${signature}`, { duration: Infinity });
       toast.loading('Confirming...', {
         id: 'create',
       });
@@ -283,7 +287,7 @@ export default function CreateSquadForm({}: {}) {
                 </div>
               </div>
             ),
-            error: (e) => `Failed to create squad: ${formatTransactionError(e)}`,
+            error: (e) => `Failed to create squad: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
           })
         }
       >

--- a/src/components/CreateSquadForm.tsx
+++ b/src/components/CreateSquadForm.tsx
@@ -77,15 +77,17 @@ export default function CreateSquadForm({}: {}) {
         programId.toBase58()
       );
 
+      toast.loading('Waiting for wallet approval...', { id: 'create', duration: Infinity });
+
       const signature = await sendTransaction(transaction, connection, {
         skipPreflight: true,
         signers: [createKey],
       });
       signatureRef.current = signature;
-      toast.info(`Sending ${signature}`, { duration: Infinity });
-      toast.loading('Confirming...', {
-        id: 'create',
-      });
+
+      const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+      toast.info(`Sent: ${signature}`, { duration: 6000 });
+      toast.info(`Confirming: ${shortSig}`, { id: 'create', duration: Infinity });
 
       const [confirmed] = await waitForConfirmation(connection, [signature]);
       if (!confirmed) {
@@ -250,12 +252,10 @@ export default function CreateSquadForm({}: {}) {
         </div>
       </div>
       <Button
-        onClick={() =>
-          toast.promise(onSubmit(submitHandler), {
-            id: 'create',
-            duration: 10000,
-            loading: 'Building Transaction...',
-            success: (res) => (
+        onClick={async () => {
+          try {
+            const res = await onSubmit(submitHandler);
+            toast.success(
               <div className="w-full flex items-center justify-between">
                 <div className="flex gap-4 items-center">
                   <CheckSquare className="w-4 h-4 text-green-600" />
@@ -285,11 +285,16 @@ export default function CreateSquadForm({}: {}) {
                     <ExternalLink className="w-4 h-4 hover:text-stone-500" />
                   </Link>
                 </div>
-              </div>
-            ),
-            error: (e) => `Failed to create squad: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-          })
-        }
+              </div>,
+              { id: 'create', duration: 10000 }
+            );
+          } catch (e) {
+            toast.error(
+              `Failed to create squad: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+              { id: 'create' }
+            );
+          }
+        }}
       >
         Create Squad
       </Button>

--- a/src/components/CreateSquadForm.tsx
+++ b/src/components/CreateSquadForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Member, createMultisig } from '@/lib/createSquad';
+import { formatTransactionError } from '@/lib/utils';
 import { Keypair, PublicKey } from '@solana/web3.js';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { CheckSquare, Copy, ExternalLink, PlusCircleIcon, XIcon } from 'lucide-react';
@@ -282,7 +283,7 @@ export default function CreateSquadForm({}: {}) {
                 </div>
               </div>
             ),
-            error: (e) => `Failed to create squad: ${e}`,
+            error: (e) => `Failed to create squad: ${formatTransactionError(e)}`,
           })
         }
       >

--- a/src/components/CreateTransactionButton.tsx
+++ b/src/components/CreateTransactionButton.tsx
@@ -108,27 +108,22 @@ const CreateTransaction = () => {
           </Button>
           {multisigAddress && (
             <Button
-              onClick={() =>
-                toast.promise(
-                  importTransaction(
+              onClick={async () => {
+                try {
+                  await importTransaction(
                     tx,
                     connection,
                     multisigAddress,
                     programId.toBase58(),
                     vaultIndex,
                     wallet
-                  ),
-                  {
-                    id: 'transaction',
-                    loading: 'Building transaction...',
-                    success: () => {
-                      setOpen(false);
-                      return 'Transaction proposed.';
-                    },
-                    error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
-                  }
-                )
-              }
+                  );
+                  setOpen(false);
+                  toast.success('Transaction proposed.', { id: 'transaction' });
+                } catch (e) {
+                  toast.error(`Failed to propose: ${formatTransactionError(e)}`, { id: 'transaction' });
+                }
+              }}
             >
               Import
             </Button>

--- a/src/components/CreateTransactionButton.tsx
+++ b/src/components/CreateTransactionButton.tsx
@@ -18,11 +18,13 @@ import { toast } from 'sonner';
 import { simulateEncodedTransaction } from '@/lib/transaction/simulateEncodedTransaction';
 import { importTransaction } from '@/lib/transaction/importTransaction';
 import { useMultisigData } from '@/hooks/useMultisigData';
+import { useAccess } from '@/hooks/useAccess';
 import invariant from 'invariant';
 import { VaultSelector } from './VaultSelector';
 
 const CreateTransaction = () => {
   const wallet = useWallet();
+  const hasAccess = useAccess();
 
   const [tx, setTx] = useState('');
   const [open, setOpen] = useState(false);
@@ -66,8 +68,8 @@ const CreateTransaction = () => {
   return (
     <Dialog open={open} onOpenChange={setOpen} modal={false}>
       <DialogTrigger
-        className={`h-10 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground ${!wallet || !wallet.publicKey ? `bg-primary/50 hover:bg-primary/50` : `hover:bg-primary/90`}`}
-        disabled={!wallet || !wallet.publicKey}
+        className={`h-10 rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground ${!hasAccess ? `bg-primary/50 hover:bg-primary/50` : `hover:bg-primary/90`}`}
+        disabled={!hasAccess}
       >
         Import Transaction
       </DialogTrigger>

--- a/src/components/CreateTransactionButton.tsx
+++ b/src/components/CreateTransactionButton.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/dialog';
 import * as bs58 from 'bs58';
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import { useState } from 'react';
 import * as multisig from '@sqds/multisig';
 import { useWallet } from '@solana/wallet-adapter-react';
@@ -97,9 +98,7 @@ const CreateTransaction = () => {
                 id: 'simulation',
                 loading: 'Building simulation...',
                 success: 'Simulation successful.',
-                error: (e) => {
-                  return `${e}`;
-                },
+                error: (e) => formatTransactionError(e),
               });
             }}
           >
@@ -124,7 +123,7 @@ const CreateTransaction = () => {
                       setOpen(false);
                       return 'Transaction proposed.';
                     },
-                    error: (e) => `Failed to propose: ${e}`,
+                    error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
                   }
                 )
               }

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -203,7 +203,12 @@ const ExecuteButton = ({
       }
     }
     closeDialog();
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+      queryClient.invalidateQueries({ queryKey: ['balance'] }),
+      queryClient.invalidateQueries({ queryKey: ['tokenBalances'] }),
+    ]);
   };
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -62,13 +62,12 @@ const ExecuteButton = ({
       throw 'Wallet not connected';
     }
     const member = wallet.publicKey;
-    if (!wallet.signAllTransactions) return;
+    if (!wallet.signAllTransactions) throw 'Connected wallet does not support signing multiple transactions';
     signaturesRef.current = [];
     let bigIntTransactionIndex = BigInt(transactionIndex);
 
     if (!isTransactionReady) {
-      toast.error('Proposal has not reached threshold.');
-      return;
+      throw 'Proposal has not reached threshold';
     }
 
     const [transactionPda] = multisig.getTransactionPda({

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -16,7 +16,7 @@ import { DialogTrigger } from './ui/dialog';
 import { DialogContent, DialogTitle } from './ui/dialog';
 import { useRef, useState } from 'react';
 import { Input } from './ui/input';
-import { range } from '@/lib/utils';
+import { range, formatTransactionError } from '@/lib/utils';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import { useQueryClient } from '@tanstack/react-query';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
@@ -231,7 +231,7 @@ const ExecuteButton = ({
               id: 'transaction',
               loading: 'Loading...',
               success: 'Transaction executed.',
-              error: (e) => `Failed to execute: ${e}${signaturesRef.current.length ? ` (${signaturesRef.current.join(', ')})` : ''}`,
+              error: (e) => `Failed to execute: ${formatTransactionError(e)}${signaturesRef.current.length ? ` (${signaturesRef.current.join(', ')})` : ''}`,
             })
           }
           className="mr-2"

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -184,7 +184,8 @@ const ExecuteButton = ({
       signatures.push(signature);
       signaturesRef.current.push(signature);
 
-      toast.loading(`Confirming${label}...`, { id: 'transaction' });
+      toast.info(`Sending${label} ${signature}`, { duration: Infinity });
+      toast.loading(`Confirming${label} ${signature}...`, { duration: Infinity });
 
       const [confirmed] = await waitForConfirmation(connection, [signature]);
       if (!confirmed) {

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -16,8 +16,9 @@ import { DialogTrigger } from './ui/dialog';
 import { DialogContent, DialogTitle } from './ui/dialog';
 import { useRef, useState } from 'react';
 import { Input } from './ui/input';
-import { range, formatTransactionError } from '@/lib/utils';
+import { range, formatTransactionError, isMember } from '@/lib/utils';
 import { useMultisigData } from '@/hooks/useMultisigData';
+import { useMultisig } from '@/hooks/useServices';
 import { useQueryClient } from '@tanstack/react-query';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
 
@@ -50,7 +51,16 @@ const ExecuteButton = ({
   const [priorityFeeLamports, setPriorityFeeLamports] = useState<number>(5000);
   const [computeUnitBudget, setComputeUnitBudget] = useState<number>(200_000);
 
+  const { data: multisigConfig } = useMultisig();
+  const connectedMember = wallet.publicKey
+    ? isMember(wallet.publicKey, multisigConfig?.members ?? [])
+    : undefined;
+  const hasExecutePermission = connectedMember
+    ? multisig.types.Permissions.has(connectedMember.permissions, multisig.types.Permission.Execute)
+    : true; // no wallet connected — allow click so handler can open wallet modal
+
   const isTransactionReady = !isAccountClosed && proposalStatus === 'Approved' && !isStale;
+  const isDisabled = !isTransactionReady || (!!wallet.publicKey && !hasExecutePermission);
 
   const { connection } = useMultisigData();
   const signaturesRef = useRef<string[]>([]);
@@ -198,8 +208,8 @@ const ExecuteButton = ({
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger
-        disabled={!isTransactionReady}
-        className={`mr-2 h-10 px-4 py-2 ${!isTransactionReady ? `bg-primary/50` : `bg-primary hover:bg-primary/90`} rounded-md text-primary-foreground`}
+        disabled={isDisabled}
+        className={`mr-2 h-10 px-4 py-2 ${isDisabled ? `bg-primary/50` : `bg-primary hover:bg-primary/90`} rounded-md text-primary-foreground`}
         onClick={() => setIsOpen(true)}
       >
         Execute
@@ -225,7 +235,7 @@ const ExecuteButton = ({
           value={computeUnitBudget}
         />
         <Button
-          disabled={!isTransactionReady}
+          disabled={isDisabled}
           onClick={() =>
             toast.promise(executeTransaction, {
               id: 'transaction',

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -57,10 +57,10 @@ const ExecuteButton = ({
     : undefined;
   const hasExecutePermission = connectedMember
     ? multisig.types.Permissions.has(connectedMember.permissions, multisig.types.Permission.Execute)
-    : true; // no wallet connected — allow click so handler can open wallet modal
+    : false;
 
   const isTransactionReady = !isAccountClosed && proposalStatus === 'Approved' && !isStale;
-  const isDisabled = !isTransactionReady || (!!wallet.publicKey && !hasExecutePermission);
+  const isDisabled = !wallet.publicKey || !isTransactionReady || !hasExecutePermission;
 
   const { connection } = useMultisigData();
   const signaturesRef = useRef<string[]>([]);

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -80,6 +80,9 @@ const ExecuteButton = ({
       throw 'Proposal has not reached threshold';
     }
 
+    // Stage 1: waiting for wallet
+    toast.loading('Waiting for wallet approval...', { id: 'execute', duration: Infinity });
+
     const [transactionPda] = multisig.getTransactionPda({
       multisigPda: new PublicKey(multisigPda),
       index: bigIntTransactionIndex,
@@ -183,25 +186,32 @@ const ExecuteButton = ({
 
     const signedTransactions = await wallet.signAllTransactions(transactions);
 
-    const signatures: string[] = [];
     for (let i = 0; i < signedTransactions.length; i++) {
       const label =
         signedTransactions.length > 1 ? ` (${i + 1}/${signedTransactions.length})` : '';
 
+      // Stage 2: sending
+      toast.loading(`Sending transaction${label}...`, { id: 'execute', duration: Infinity });
+
       const signature = await connection.sendRawTransaction(signedTransactions[i].serialize(), {
         skipPreflight: true,
       });
-      signatures.push(signature);
       signaturesRef.current.push(signature);
 
-      toast.info(`Sending${label} ${signature}`, { duration: Infinity });
-      toast.loading(`Confirming${label} ${signature}...`, { duration: Infinity });
+      // Stage 3: confirming — stacks a brief "Sent" announcement alongside the progress toast
+      const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+      toast.info(`Sent${label}: ${signature}`, { duration: 6000 });
+      toast.info(`Confirming${label}: ${shortSig}`, { id: 'execute', duration: Infinity });
 
       const [confirmed] = await waitForConfirmation(connection, [signature]);
       if (!confirmed) {
         throw `Transaction${label} failed or timed out. Check ${signature}`;
       }
     }
+
+    // Stage 4: confirmed
+    toast.success('Transaction executed.', { id: 'execute' });
+
     closeDialog();
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['transactions'] }),
@@ -241,14 +251,16 @@ const ExecuteButton = ({
         />
         <Button
           disabled={isDisabled}
-          onClick={() =>
-            toast.promise(executeTransaction, {
-              id: 'transaction',
-              loading: 'Loading...',
-              success: 'Transaction executed.',
-              error: (e) => `Failed to execute: ${formatTransactionError(e)}${signaturesRef.current.length ? ` (${signaturesRef.current.join(', ')})` : ''}`,
-            })
-          }
+          onClick={async () => {
+            try {
+              await executeTransaction();
+            } catch (e) {
+              toast.error(
+                `Failed to execute: ${formatTransactionError(e)}${signaturesRef.current.length ? ` (${signaturesRef.current.join(', ')})` : ''}`,
+                { id: 'execute' }
+              );
+            }
+          }}
           className="mr-2"
         >
           Execute

--- a/src/components/ExecuteButton.tsx
+++ b/src/components/ExecuteButton.tsx
@@ -32,6 +32,7 @@ type ExecuteButtonProps = {
   proposalStatus: string;
   programId: string;
   isStale: boolean;
+  isAccountClosed: boolean;
 };
 
 const ExecuteButton = ({
@@ -40,6 +41,7 @@ const ExecuteButton = ({
   proposalStatus,
   programId,
   isStale,
+  isAccountClosed,
 }: ExecuteButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const closeDialog = () => setIsOpen(false);
@@ -48,7 +50,7 @@ const ExecuteButton = ({
   const [priorityFeeLamports, setPriorityFeeLamports] = useState<number>(5000);
   const [computeUnitBudget, setComputeUnitBudget] = useState<number>(200_000);
 
-  const isTransactionReady = proposalStatus === 'Approved' && !isStale;
+  const isTransactionReady = !isAccountClosed && proposalStatus === 'Approved' && !isStale;
 
   const { connection } = useMultisigData();
   const signaturesRef = useRef<string[]>([]);

--- a/src/components/MultisigLookup.tsx
+++ b/src/components/MultisigLookup.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import { useMultisigData } from '../hooks/useMultisigData';
 import {
   AddressLookupTableAccount,
@@ -126,7 +127,7 @@ const MultisigLookup: React.FC<MultisigLookupProps> = ({ onUpdate }) => {
             id: 'mksKeySearch',
             loading: 'Loading...',
             success: 'Search finished.',
-            error: (e) => `Failed to propose: ${e}`,
+            error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
           })
         }
         className="mt-4"

--- a/src/components/RejectButton.tsx
+++ b/src/components/RejectButton.tsx
@@ -52,7 +52,7 @@ const RejectButton = ({
     isStale ||
     !rejectableStatuses.includes(proposalStatus) ||
     hasAlreadyRejected ||
-    !hasVotePermission;
+    (!!wallet.publicKey && !hasVotePermission);
   const signatureRef = useRef<string>('');
 
   const rejectTransaction = async () => {
@@ -61,11 +61,6 @@ const RejectButton = ({
       throw 'Wallet not connected';
     }
     let bigIntTransactionIndex = BigInt(transactionIndex);
-
-    if (isDisabled) {
-      toast.error("You can't reject this proposal.");
-      return;
-    }
 
     const transaction = new Transaction();
     if (proposalStatus === 'None') {

--- a/src/components/RejectButton.tsx
+++ b/src/components/RejectButton.tsx
@@ -10,7 +10,7 @@ import { useMultisigData } from '@/hooks/useMultisigData';
 import { useQueryClient } from '@tanstack/react-query';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
 import { useMultisig } from '@/hooks/useServices';
-import { isMember } from '@/lib/utils';
+import { isMember, formatTransactionError } from '@/lib/utils';
 
 type RejectButtonProps = {
   multisigPda: string;
@@ -121,7 +121,7 @@ const RejectButton = ({
           id: 'transaction',
           loading: 'Loading...',
           success: 'Transaction rejected.',
-          error: (e) => `Failed to reject: ${e}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+          error: (e) => `Failed to reject: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
         })
       }
       className="mr-2"

--- a/src/components/RejectButton.tsx
+++ b/src/components/RejectButton.tsx
@@ -93,33 +93,37 @@ const RejectButton = ({
 
     transaction.add(rejectProposalInstruction);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, {
-      duration: Infinity,
-    });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Transaction rejected.', { id: 'transaction' });
     await queryClient.invalidateQueries({ queryKey: ['transactions'] });
   };
   return (
     <Button
       disabled={isDisabled}
-      onClick={() =>
-        toast.promise(rejectTransaction, {
-          id: 'transaction',
-          loading: 'Loading...',
-          success: 'Transaction rejected.',
-          error: (e) => `Failed to reject: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-        })
-      }
+      onClick={async () => {
+        try {
+          await rejectTransaction();
+        } catch (e) {
+          toast.error(
+            `Failed to reject: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+            { id: 'transaction' }
+          );
+        }
+      }}
       className="mr-2"
     >
       Reject

--- a/src/components/RejectButton.tsx
+++ b/src/components/RejectButton.tsx
@@ -9,6 +9,8 @@ import { toast } from 'sonner';
 import { useMultisigData } from '@/hooks/useMultisigData';
 import { useQueryClient } from '@tanstack/react-query';
 import { waitForConfirmation } from '../lib/transactionConfirmation';
+import { useMultisig } from '@/hooks/useServices';
+import { isMember } from '@/lib/utils';
 
 type RejectButtonProps = {
   multisigPda: string;
@@ -16,6 +18,8 @@ type RejectButtonProps = {
   proposalStatus: string;
   programId: string;
   isStale: boolean;
+  rejectedMembers: PublicKey[];
+  isAccountClosed: boolean;
 };
 
 const RejectButton = ({
@@ -24,15 +28,31 @@ const RejectButton = ({
   proposalStatus,
   programId,
   isStale,
+  rejectedMembers,
+  isAccountClosed,
 }: RejectButtonProps) => {
   const wallet = useWallet();
   const walletModal = useWalletModal();
 
   const { connection } = useMultisigData();
   const queryClient = useQueryClient();
+  const { data: multisigConfig } = useMultisig();
 
   const rejectableStatuses = ['None', 'Active', 'Draft'];
-  const isDisabled = isStale || !rejectableStatuses.includes(proposalStatus);
+  const hasAlreadyRejected =
+    !!wallet.publicKey && rejectedMembers.some((k) => k.equals(wallet.publicKey!));
+  const connectedMember = wallet.publicKey
+    ? isMember(wallet.publicKey, multisigConfig?.members ?? [])
+    : undefined;
+  const hasVotePermission = connectedMember
+    ? multisig.types.Permissions.has(connectedMember.permissions, multisig.types.Permission.Vote)
+    : false;
+  const isDisabled =
+    isAccountClosed ||
+    isStale ||
+    !rejectableStatuses.includes(proposalStatus) ||
+    hasAlreadyRejected ||
+    !hasVotePermission;
   const signatureRef = useRef<string>('');
 
   const rejectTransaction = async () => {

--- a/src/components/RejectButton.tsx
+++ b/src/components/RejectButton.tsx
@@ -48,11 +48,12 @@ const RejectButton = ({
     ? multisig.types.Permissions.has(connectedMember.permissions, multisig.types.Permission.Vote)
     : false;
   const isDisabled =
+    !wallet.publicKey ||
     isAccountClosed ||
     isStale ||
     !rejectableStatuses.includes(proposalStatus) ||
     hasAlreadyRejected ||
-    (!!wallet.publicKey && !hasVotePermission);
+    !hasVotePermission;
   const signatureRef = useRef<string>('');
 
   const rejectTransaction = async () => {

--- a/src/components/RemoveMemberButton.tsx
+++ b/src/components/RemoveMemberButton.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Connection, PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import { Button } from './ui/button';
 import { formatTransactionError } from '@/lib/utils';
@@ -30,6 +31,7 @@ const RemoveMemberButton = ({
   const member = new PublicKey(memberKey);
   const queryClient = useQueryClient();
   const { connection } = useMultisigData();
+  const signatureRef = useRef<string>('');
 
   const removeMember = async () => {
     if (!wallet.publicKey) {
@@ -69,6 +71,8 @@ const RemoveMemberButton = ({
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -86,7 +90,7 @@ const RemoveMemberButton = ({
           id: 'transaction',
           loading: 'Submitting...',
           success: 'Remove Member action proposed.',
-          error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+          error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
         })
       }
     >

--- a/src/components/RemoveMemberButton.tsx
+++ b/src/components/RemoveMemberButton.tsx
@@ -1,5 +1,6 @@
 import { Connection, PublicKey, TransactionMessage, VersionedTransaction } from '@solana/web3.js';
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import * as multisig from '@sqds/multisig';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
@@ -85,7 +86,7 @@ const RemoveMemberButton = ({
           id: 'transaction',
           loading: 'Submitting...',
           success: 'Remove Member action proposed.',
-          error: (e) => `Failed to propose: ${e}`,
+          error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
         })
       }
     >

--- a/src/components/RemoveMemberButton.tsx
+++ b/src/components/RemoveMemberButton.tsx
@@ -36,7 +36,7 @@ const RemoveMemberButton = ({
   const removeMember = async () => {
     if (!wallet.publicKey) {
       walletModal.setVisible(true);
-      return;
+      throw 'Wallet not connected';
     }
     let bigIntTransactionIndex = BigInt(transactionIndex);
 

--- a/src/components/RemoveMemberButton.tsx
+++ b/src/components/RemoveMemberButton.tsx
@@ -68,18 +68,22 @@ const RemoveMemberButton = ({
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Remove member action proposed.', { id: 'transaction' });
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['transactions'] }),
       queryClient.invalidateQueries({ queryKey: ['multisig'] }),
@@ -88,14 +92,16 @@ const RemoveMemberButton = ({
   return (
     <Button
       disabled={!isMember}
-      onClick={() =>
-        toast.promise(removeMember, {
-          id: 'transaction',
-          loading: 'Submitting...',
-          success: 'Remove Member action proposed.',
-          error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-        })
-      }
+      onClick={async () => {
+        try {
+          await removeMember();
+        } catch (e) {
+          toast.error(
+            `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+            { id: 'transaction' }
+          );
+        }
+      }}
     >
       Remove
     </Button>

--- a/src/components/RemoveMemberButton.tsx
+++ b/src/components/RemoveMemberButton.tsx
@@ -80,7 +80,10 @@ const RemoveMemberButton = ({
     if (!sent[0]) {
       throw `Transaction failed or unable to confirm. Check ${signature}`;
     }
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+    ]);
   };
   return (
     <Button

--- a/src/components/SendSolButton.tsx
+++ b/src/components/SendSolButton.tsx
@@ -106,18 +106,22 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Transfer proposed.', { id: 'transaction' });
     setAmount('');
     setRecipient('');
     closeDialog();
@@ -159,14 +163,16 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
           <p className="text-xs text-red-500">Invalid amount</p>
         )}
         <Button
-          onClick={() =>
-            toast.promise(transfer, {
-              id: 'transaction',
-              loading: 'Loading...',
-              success: 'Transfer proposed.',
-              error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-            })
-          }
+          onClick={async () => {
+            try {
+              await transfer();
+            } catch (e) {
+              toast.error(
+                `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+                { id: 'transaction' }
+              );
+            }
+          }}
           disabled={!isPublickey(recipient)}
         >
           Transfer

--- a/src/components/SendSolButton.tsx
+++ b/src/components/SendSolButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '~/components/ui/dialog';
 import { Button } from './ui/button';
 import { formatTransactionError } from '@/lib/utils';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import * as multisig from '@sqds/multisig';
 import { useWallet } from '@solana/wallet-adapter-react';
 import {
@@ -42,6 +42,7 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
   const [recipient, setRecipient] = useState('');
   const { connection, programId } = useMultisigData();
   const queryClient = useQueryClient();
+  const signatureRef = useRef<string>('');
   const parsedAmount = parseFloat(amount);
   const isAmountValid = !isNaN(parsedAmount) && parsedAmount > 0;
   const isMember = useAccess();
@@ -108,6 +109,8 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -158,7 +161,7 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
               id: 'transaction',
               loading: 'Loading...',
               success: 'Transfer proposed.',
-              error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+              error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
             })
           }
           disabled={!isPublickey(recipient)}

--- a/src/components/SendSolButton.tsx
+++ b/src/components/SendSolButton.tsx
@@ -121,7 +121,10 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
     setAmount('');
     setRecipient('');
     closeDialog();
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+    ]);
   };
 
   return (

--- a/src/components/SendSolButton.tsx
+++ b/src/components/SendSolButton.tsx
@@ -7,6 +7,7 @@ import {
   DialogTrigger,
 } from '~/components/ui/dialog';
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import { useState } from 'react';
 import * as multisig from '@sqds/multisig';
 import { useWallet } from '@solana/wallet-adapter-react';
@@ -157,7 +158,7 @@ const SendSol = ({ multisigPda, vaultIndex }: SendSolProps) => {
               id: 'transaction',
               loading: 'Loading...',
               success: 'Transfer proposed.',
-              error: (e) => `Failed to propose: ${e}`,
+              error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
             })
           }
           disabled={!isPublickey(recipient)}

--- a/src/components/SendTokensButton.tsx
+++ b/src/components/SendTokensButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '~/components/ui/dialog';
 import { Button } from './ui/button';
 import { formatTransactionError } from '@/lib/utils';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import {
   createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
@@ -53,6 +53,7 @@ const SendTokens = ({
   const { connection } = useMultisigData();
 
   const queryClient = useQueryClient();
+  const signatureRef = useRef<string>('');
   const parsedAmount = parseFloat(amount);
   const isAmountValid = !isNaN(parsedAmount) && parsedAmount > 0;
   const isMember = useAccess();
@@ -147,6 +148,8 @@ const SendTokens = ({
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
+    signatureRef.current = signature;
+    toast.info(`Sending ${signature}`, { duration: Infinity });
     toast.loading('Confirming...', {
       id: 'transaction',
     });
@@ -203,7 +206,7 @@ const SendTokens = ({
               id: 'transaction',
               loading: 'Loading...',
               success: 'Transfer proposed.',
-              error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
+              error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
             })
           }
           disabled={!isPublickey(recipient) || amount.length < 1 || !isAmountValid}

--- a/src/components/SendTokensButton.tsx
+++ b/src/components/SendTokensButton.tsx
@@ -7,6 +7,7 @@ import {
   DialogTrigger,
 } from '~/components/ui/dialog';
 import { Button } from './ui/button';
+import { formatTransactionError } from '@/lib/utils';
 import { useState } from 'react';
 import {
   createAssociatedTokenAccountIdempotentInstruction,
@@ -202,7 +203,7 @@ const SendTokens = ({
               id: 'transaction',
               loading: 'Loading...',
               success: 'Transfer proposed.',
-              error: (e) => `Failed to propose: ${e}`,
+              error: (e) => `Failed to propose: ${formatTransactionError(e)}`,
             })
           }
           disabled={!isPublickey(recipient) || amount.length < 1 || !isAmountValid}

--- a/src/components/SendTokensButton.tsx
+++ b/src/components/SendTokensButton.tsx
@@ -159,7 +159,10 @@ const SendTokens = ({
     }
     setAmount('');
     setRecipient('');
-    await queryClient.invalidateQueries({ queryKey: ['transactions'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['transactions'] }),
+      queryClient.invalidateQueries({ queryKey: ['multisig'] }),
+    ]);
     closeDialog();
   };
 

--- a/src/components/SendTokensButton.tsx
+++ b/src/components/SendTokensButton.tsx
@@ -145,18 +145,22 @@ const SendTokens = ({
 
     const transaction = new VersionedTransaction(message);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
     signatureRef.current = signature;
-    toast.info(`Sending ${signature}`, { duration: Infinity });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
-    const sent = await waitForConfirmation(connection, [signature]);
-    if (!sent[0]) {
-      throw `Transaction failed or unable to confirm. Check ${signature}`;
+
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
+    toast.success('Transfer proposed.', { id: 'transaction' });
     setAmount('');
     setRecipient('');
     await Promise.all([
@@ -204,14 +208,16 @@ const SendTokens = ({
           <p className="text-xs text-red-500">Invalid amount</p>
         )}
         <Button
-          onClick={() =>
-            toast.promise(transfer, {
-              id: 'transaction',
-              loading: 'Loading...',
-              success: 'Transfer proposed.',
-              error: (e) => `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
-            })
-          }
+          onClick={async () => {
+            try {
+              await transfer();
+            } catch (e) {
+              toast.error(
+                `Failed to propose: ${formatTransactionError(e)}${signatureRef.current ? ` (${signatureRef.current})` : ''}`,
+                { id: 'transaction' }
+              );
+            }
+          }}
           disabled={!isPublickey(recipient) || amount.length < 1 || !isAmountValid}
         >
           Transfer

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -1,4 +1,5 @@
 import * as multisig from '@sqds/multisig';
+import { PublicKey } from '@solana/web3.js';
 import ApproveButton from './ApproveButton';
 import ExecuteButton from './ExecuteButton';
 import RejectButton from './RejectButton';
@@ -13,6 +14,9 @@ interface ActionButtonsProps {
   proposalStatus: string;
   programId: string;
   isStale: boolean;
+  approvedMembers: PublicKey[];
+  rejectedMembers: PublicKey[];
+  isAccountClosed: boolean;
 }
 
 export default function TransactionTable({
@@ -25,6 +29,7 @@ export default function TransactionTable({
     transactionPda: string;
     proposal: multisig.generated.Proposal | null;
     index: bigint;
+    transactionExists: boolean;
   }[];
   programId?: string;
 }) {
@@ -58,7 +63,11 @@ export default function TransactionTable({
               </Link>
             </TableCell>
             <TableCell>
-              {stale ? '(stale)' : transaction.proposal?.status.__kind || 'None'}
+              {!transaction.transactionExists
+                ? 'Closed'
+                : stale
+                  ? '(stale)'
+                  : transaction.proposal?.status.__kind || 'None'}
             </TableCell>
             <TableCell>
               <ActionButtons
@@ -67,6 +76,9 @@ export default function TransactionTable({
                 proposalStatus={transaction.proposal?.status.__kind || 'None'}
                 programId={programId ? programId : multisig.PROGRAM_ID.toBase58()}
                 isStale={stale}
+                approvedMembers={transaction.proposal?.approved ?? []}
+                rejectedMembers={transaction.proposal?.rejected ?? []}
+                isAccountClosed={!transaction.transactionExists}
               />
             </TableCell>
           </TableRow>
@@ -82,6 +94,9 @@ function ActionButtons({
   proposalStatus,
   programId,
   isStale,
+  approvedMembers,
+  rejectedMembers,
+  isAccountClosed,
 }: ActionButtonsProps) {
   return (
     <>
@@ -91,6 +106,8 @@ function ActionButtons({
         proposalStatus={proposalStatus}
         programId={programId}
         isStale={isStale}
+        approvedMembers={approvedMembers}
+        isAccountClosed={isAccountClosed}
       />
       <RejectButton
         multisigPda={multisigPda}
@@ -98,6 +115,8 @@ function ActionButtons({
         proposalStatus={proposalStatus}
         programId={programId}
         isStale={isStale}
+        rejectedMembers={rejectedMembers}
+        isAccountClosed={isAccountClosed}
       />
       <ExecuteButton
         multisigPda={multisigPda}
@@ -105,6 +124,7 @@ function ActionButtons({
         proposalStatus={proposalStatus}
         programId={programId}
         isStale={isStale}
+        isAccountClosed={isAccountClosed}
       />
     </>
   );

--- a/src/hooks/useAccess.tsx
+++ b/src/hooks/useAccess.tsx
@@ -4,13 +4,15 @@ import { useWallet } from '@solana/wallet-adapter-react';
 import { isMember } from '@/lib/utils';
 
 export const useAccess = () => {
-  const { data: multisig } = useMultisig();
+  const { data: multisigData } = useMultisig();
   const { publicKey } = useWallet();
-  if (!multisig || !publicKey) {
+  if (!multisigData || !publicKey) {
     return false;
   }
-  // if the pubkeyKey is in members return true
-  const memberExists = isMember(publicKey, multisig.members);
-  // return true if found
-  return !!memberExists;
+  const connectedMember = isMember(publicKey, multisigData.members);
+  if (!connectedMember) return false;
+  return multisig.types.Permissions.has(
+    connectedMember.permissions,
+    multisig.types.Permission.Initiate
+  );
 };

--- a/src/hooks/useServices.tsx
+++ b/src/hooks/useServices.tsx
@@ -80,14 +80,14 @@ async function fetchTransactionData(
     programId,
   });
 
-  let proposal;
-  try {
-    proposal = await multisig.accounts.Proposal.fromAccountAddress(connection, proposalPda[0]);
-  } catch (error) {
-    proposal = null;
-  }
+  const [transactionAccountInfo, proposal] = await Promise.all([
+    connection.getAccountInfo(transactionPda[0]),
+    multisig.accounts.Proposal.fromAccountAddress(connection, proposalPda[0]).catch(() => null),
+  ]);
 
-  return { transactionPda, proposal, index };
+  const transactionExists = transactionAccountInfo !== null;
+
+  return { transactionPda, proposal, index, transactionExists };
 }
 
 export const useTransactions = (startIndex: number, endIndex: number) => {

--- a/src/hooks/useServices.tsx
+++ b/src/hooks/useServices.tsx
@@ -81,7 +81,7 @@ async function fetchTransactionData(
   });
 
   const [transactionAccountInfo, proposal] = await Promise.all([
-    connection.getAccountInfo(transactionPda[0]),
+    connection.getAccountInfo(transactionPda[0]).catch(() => null),
     multisig.accounts.Proposal.fromAccountAddress(connection, proposalPda[0]).catch(() => null),
   ]);
 

--- a/src/lib/transaction/importTransaction.ts
+++ b/src/lib/transaction/importTransaction.ts
@@ -72,16 +72,19 @@ export const importTransaction = async (
 
     const transaction = new VersionedTransaction(wrappedMessage);
 
+    toast.loading('Waiting for wallet approval...', { id: 'transaction', duration: Infinity });
+
     const signature = await wallet.sendTransaction(transaction, connection, {
       skipPreflight: true,
     });
-    toast.loading('Confirming...', {
-      id: 'transaction',
-    });
 
-    const hasSent = await waitForConfirmation(connection, [signature]);
-    if (!hasSent.every((s) => !!s)) {
-      throw `Unable to confirm transaction`;
+    const shortSig = `${signature.slice(0, 8)}...${signature.slice(-4)}`;
+    toast.info(`Sent: ${signature}`, { duration: 6000 });
+    toast.info(`Confirming: ${shortSig}`, { id: 'transaction', duration: Infinity });
+
+    const [confirmed] = await waitForConfirmation(connection, [signature]);
+    if (!confirmed) {
+      throw `Transaction failed or timed out. Check ${signature}`;
     }
   } catch (error) {
     throw error;

--- a/src/lib/transactionConfirmation.ts
+++ b/src/lib/transactionConfirmation.ts
@@ -2,6 +2,16 @@ import { Connection, SignatureStatus } from '@solana/web3.js';
 
 const TIMEOUT_MS = 30_000;
 const INITIAL_DELAY_MS = 1_000;
+const RPC_CALL_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`RPC call timed out after ${ms}ms`)), ms)
+    ),
+  ]);
+}
 
 export async function waitForConfirmation(
   connection: Connection,
@@ -14,7 +24,17 @@ export async function waitForConfirmation(
     await new Promise((r) => setTimeout(r, delayMs));
     delayMs *= 2;
 
-    const { value: statuses } = await connection.getSignatureStatuses(signatures);
+    let statuses: (SignatureStatus | null)[];
+    try {
+      const result = await withTimeout(
+        connection.getSignatureStatuses(signatures, { searchTransactionHistory: true }),
+        RPC_CALL_TIMEOUT_MS
+      );
+      statuses = result.value;
+    } catch {
+      // RPC call timed out or failed — skip this iteration and retry
+      continue;
+    }
 
     // Explicit on-chain failure — return null for failed, status for others
     if (statuses.some((s) => s?.err != null)) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,3 +27,17 @@ export const renderPermissions = (permissionsMask: number) => {
 export const isMember = (publicKey: PublicKey, members: multisigTypes.Member[]) => {
   return members.find((v: multisigTypes.Member) => v.key.equals(publicKey));
 };
+
+export function formatTransactionError(e: unknown): string {
+  if (e instanceof Error) {
+    let msg = e.message;
+    const raw = (e as any).error;
+    if (raw != null) {
+      try {
+        msg += `: ${typeof raw === 'string' ? raw : JSON.stringify(raw)}`;
+      } catch { /* ignore unserializable error details */ }
+    }
+    return msg;
+  }
+  return String(e);
+}


### PR DESCRIPTION
This pull request focuses on improving the user experience and error handling for all transaction-related actions in the multisig UI. The main changes include more informative and consistent toast notifications during transaction flows, improved error reporting with formatted messages and transaction signatures, and additional checks to prevent users without appropriate permissions from taking actions. The updates also refactor the button click handlers to use explicit async/await error handling instead of `toast.promise`.

**User Experience and Error Handling Improvements**

- Replaced `toast.promise` with explicit async/await error handling for all transaction button actions, providing more control over toast notifications and error formatting. Now, users see clear loading, confirmation, and success messages, and errors include formatted details and the transaction signature when available. (`src/components/AddMemberInput.tsx`, `src/components/ApproveButton.tsx`, `src/components/ChangeThresholdInput.tsx`, `src/components/ChangeUpgradeAuthorityInput.tsx`, `src/components/CreateProgramUpgradeInput.tsx`, `src/components/CreateSquadForm.tsx`) [[1]](diffhunk://#diff-e3fd1be99c6688db9aa85512708d2df722c579939b249fdfcff20b9ef3bdeb97R80-R99) [[2]](diffhunk://#diff-e3fd1be99c6688db9aa85512708d2df722c579939b249fdfcff20b9ef3bdeb97L98-R118) [[3]](diffhunk://#diff-2996ff61f02a0ca22a0fdc6b1222327b545484d84491419457885e87a87a940cR90-R120) [[4]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8R94-R113) [[5]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8L111-R137) [[6]](diffhunk://#diff-b36f15c6d37232519bad2730f3a7b6be9d4e2491ff9682270eadd00ae6c34febR119-R138) [[7]](diffhunk://#diff-b36f15c6d37232519bad2730f3a7b6be9d4e2491ff9682270eadd00ae6c34febL138-R158) [[8]](diffhunk://#diff-4272b7104df9c8e1a099736c04615bbab159bafd2b93674e1f58fec549e8ea62R142-R157) [[9]](diffhunk://#diff-4272b7104df9c8e1a099736c04615bbab159bafd2b93674e1f58fec549e8ea62L167-R184) [[10]](diffhunk://#diff-45074727a2ee292ef64b3a6f5c30568889bc8344e14c03a165eb2ce270241a9dR43)
- Added toast notifications for each transaction stage: waiting for wallet approval, transaction sent (with short signature), confirming, and final success. Errors during any stage are now surfaced with more context. (`src/components/AddMemberInput.tsx`, `src/components/ApproveButton.tsx`, `src/components/ChangeThresholdInput.tsx`, `src/components/ChangeUpgradeAuthorityInput.tsx`, `src/components/CreateProgramUpgradeInput.tsx`) [[1]](diffhunk://#diff-e3fd1be99c6688db9aa85512708d2df722c579939b249fdfcff20b9ef3bdeb97R80-R99) [[2]](diffhunk://#diff-2996ff61f02a0ca22a0fdc6b1222327b545484d84491419457885e87a87a940cR90-R120) [[3]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8R94-R113) [[4]](diffhunk://#diff-b36f15c6d37232519bad2730f3a7b6be9d4e2491ff9682270eadd00ae6c34febR119-R138) [[5]](diffhunk://#diff-4272b7104df9c8e1a099736c04615bbab159bafd2b93674e1f58fec549e8ea62R142-R157)

**Permission and Access Control Enhancements**

- Added checks to ensure actions like approving proposals or changing settings are only enabled for users with the proper permissions (e.g., must be a member with voting rights, proposal not already approved, account not closed). (`src/components/ApproveButton.tsx`, `src/components/ChangeThresholdInput.tsx`) [[1]](diffhunk://#diff-2996ff61f02a0ca22a0fdc6b1222327b545484d84491419457885e87a87a940cR30-R51) [[2]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8R26-R31) [[3]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8L111-R137)

**Refactoring and Code Consistency**

- Introduced `useRef` to track the transaction signature for error reporting across all affected components. (`src/components/AddMemberInput.tsx`, `src/components/ApproveButton.tsx`, `src/components/ChangeThresholdInput.tsx`, `src/components/ChangeUpgradeAuthorityInput.tsx`, `src/components/CreateProgramUpgradeInput.tsx`, `src/components/CreateSquadForm.tsx`) [[1]](diffhunk://#diff-e3fd1be99c6688db9aa85512708d2df722c579939b249fdfcff20b9ef3bdeb97R34-R40) [[2]](diffhunk://#diff-2996ff61f02a0ca22a0fdc6b1222327b545484d84491419457885e87a87a940cR30-R51) [[3]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8R26-R31) [[4]](diffhunk://#diff-b36f15c6d37232519bad2730f3a7b6be9d4e2491ff9682270eadd00ae6c34febR37-R44) [[5]](diffhunk://#diff-4272b7104df9c8e1a099736c04615bbab159bafd2b93674e1f58fec549e8ea62R35) [[6]](diffhunk://#diff-45074727a2ee292ef64b3a6f5c30568889bc8344e14c03a165eb2ce270241a9dR43)
- Updated error handling to throw immediately if the wallet is not connected, ensuring consistent user prompts to connect their wallet before proceeding. (`src/components/AddMemberInput.tsx`, `src/components/ChangeThresholdInput.tsx`, `src/components/ChangeUpgradeAuthorityInput.tsx`) [[1]](diffhunk://#diff-e3fd1be99c6688db9aa85512708d2df722c579939b249fdfcff20b9ef3bdeb97R34-R40) [[2]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8L55-R59) [[3]](diffhunk://#diff-b36f15c6d37232519bad2730f3a7b6be9d4e2491ff9682270eadd00ae6c34febR37-R44)

**Utility and Imports**

- Imported and used the new `formatTransactionError` utility across all transaction components for consistent error formatting. (`src/components/AddMemberInput.tsx`, `src/components/ApproveButton.tsx`, `src/components/ChangeThresholdInput.tsx`, `src/components/ChangeUpgradeAuthorityInput.tsx`, `src/components/CreateProgramUpgradeInput.tsx`, `src/components/CreateSquadForm.tsx`) [[1]](diffhunk://#diff-e3fd1be99c6688db9aa85512708d2df722c579939b249fdfcff20b9ef3bdeb97R2-R5) [[2]](diffhunk://#diff-2996ff61f02a0ca22a0fdc6b1222327b545484d84491419457885e87a87a940cR11-R21) [[3]](diffhunk://#diff-fdc574198a94938bd4649b354ece5a0906193b7d01e2c4d2fd56426ad0f482a8R2-R5) [[4]](diffhunk://#diff-b36f15c6d37232519bad2730f3a7b6be9d4e2491ff9682270eadd00ae6c34febL5-R8) [[5]](diffhunk://#diff-4272b7104df9c8e1a099736c04615bbab159bafd2b93674e1f58fec549e8ea62L4-R7) [[6]](diffhunk://#diff-45074727a2ee292ef64b3a6f5c30568889bc8344e14c03a165eb2ce270241a9dR3-R5)